### PR TITLE
Update to 1.19.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,14 +96,14 @@
         <dependency>
             <groupId>com.github.stefvanschie.inventoryframework</groupId>
             <artifactId>IF</artifactId>
-            <version>0.10.8</version>
+            <version>0.10.9</version>
         </dependency>
 
         <!--Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.26</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The inventory plugin that I use to do all the gui stuff had a bug in the 1.19.3 version. This bug was fixed and my plugin works fine now!